### PR TITLE
Generalize command structure across frames

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -16,14 +16,16 @@ declare global {
 			 * Current image src.
 			 */
 			src: string;
-			/**
-			 * List of commands to reexec to get to the current state.
-			 */
-			commands: Command[];
+			undoStack: Command[];
+			redoStack: Command[];
 		}
 
+		// Holds a function to execute a series of commands, and a series of
+		// commands to execute
 		type Command = {
-			execute: () => void;
+			// A list of commands that can be executed. Each command is a function.
+			commands: { (...args: any[]): void }[];
+			execute: (commands: { (...args: any[]): void }[], ...args: any[]) => void;
 		}
 	}
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -7,6 +7,24 @@ declare global {
 		// interface PageData {}
 		// interface PageState {}
 		// interface Platform {}
+		type Frame = {
+			/**
+			 * Whether or not the command stack has been modified since the last image save.
+			 */
+			dirty: boolean;
+			/**
+			 * Current image src.
+			 */
+			src: string;
+			/**
+			 * List of commands to reexec to get to the current state.
+			 */
+			commands: Command[];
+		}
+
+		type Command = {
+			execute: () => void;
+		}
 	}
 }
 

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { size, matrix, frames } from "$lib/stores";
   import { onMount } from "svelte";
-  import Page from "../../routes/+page.svelte";
 
   export let playing: boolean = false;
   export let panEnabled: boolean = false;

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -76,11 +76,9 @@
    */
   const pushCommandToStack = () => {
     if (actionCommands.length === 0) return;
-    /**
-     * @type {App.Command}
-     */
-    let command = {
+    let command: App.Command = {
       // shallow copy of commands for given state
+      // TODO: is shallow copy necessary?
       commands: [...actionCommands],
       // @ts-ignore (sveltekit try to type inlined JS challenge (impossible))
       execute: (commands, ctx) => {
@@ -88,6 +86,11 @@
       },
     };
     frame.undoStack = [...frame.undoStack, command];
+
+    // we have a new series of commands necessary to replicate the frame state,
+    // so we can clear the redo stack if there are any commands in it.
+    if (frame.redoStack.length > 0) frame.redoStack = [];
+
     // TODO: is this necessary?
     $frames[frameIdx] = frame;
     actionCommands = [];

--- a/src/lib/frames.ts
+++ b/src/lib/frames.ts
@@ -1,0 +1,14 @@
+/**
+ * Creates an empty frame object
+ *
+ * @param canvas Canvas element to generate empty frame image from
+ * @returns {App.Frame} Empty frame object
+ */
+export const createEmptyFrame = (canvas: HTMLCanvasElement): App.Frame => ({
+  dirty: false,
+  src: canvas.toDataURL(),
+  redoStack: [],
+  undoStack: [],
+});
+
+

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -2,4 +2,4 @@ import {writable, type Writable} from 'svelte/store';
 
 export const size = writable([0, 0]);
 export const matrix = writable([1, 0, 0, 1, 0, 0]);
-export const commands: Writable<[number, number, number, number][][]> = writable([]);
+export const frames: Writable<App.Frame[]> = writable([]);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,12 @@
 
   let viewTransforms = transforms();
 
+  /**
+   * Binding for current frame that clears canvas and updates frame command
+   * stack.
+   */
+  let clearFrame: () => void;
+
   let frameIdx = 0;
   $: frame = $frames[frameIdx];
 
@@ -61,11 +67,6 @@
     requestAnimationFrame(update);
   });
 
-  const clear = () => {
-    if (!ctx) throw new Error("no context");
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-  };
-
   let mousePos = [0, 0];
   let lastPos = [0, 0];
   const handleMove = (e: MouseEvent) => {
@@ -120,7 +121,8 @@
       ];
     });
 
-    clear();
+    if (!ctx) throw new Error("no context");
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
     if (frameIdx === $frames.length - 1) {
       // if at end of list, create a new frame
       frames.update((f) => [
@@ -166,7 +168,13 @@
     style:width="{$size[0]}px"
     style:height="{$size[1]}px"
   >
-    <Canvas bind:playing bind:canvas bind:panEnabled bind:frameIdx />
+    <Canvas
+      bind:playing
+      bind:canvas
+      bind:panEnabled
+      bind:frameIdx
+      bind:clearFrame
+    />
     {#if $frames.length > 0}
       {#each { length: Math.max(1, Math.min(overlayCount, frameIdx)) } as _, i}
         {#if frameIdx - i - 1 >= 0}
@@ -228,7 +236,7 @@
 
   <fieldset>
     <legend>canvas controls</legend>
-    <button on:click={clear}>Clear</button>
+    <button on:click={clearFrame}>Clear</button>
     <label class="lbl-horz">
       x
       <input type="number" bind:value={$size[0]} min="1" />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -258,7 +258,22 @@
       <img {src} on:click={() => (frameIdx = i)} alt="" />
       <button
         class="delete"
-        on:click={() => frames.update((f) => f.filter((_, j) => i !== j))}
+        on:click={() => {
+          if ($frames.length === 1) {
+            frames.update((f) => [
+              {
+                src: "",
+                dirty: false,
+                undoStack: [],
+                redoStack: [],
+              },
+            ]);
+            frameIdx = 0;
+            return;
+          }
+          frames.update((f) => f.filter((_, j) => i !== j));
+          if (frameIdx >= i) frameIdx--;
+        }}
       >
         X
       </button>


### PR DESCRIPTION
- [x] redraw actual canvas state if moving to existing frame with commands (dd50ad3)
- [x] save instances where canvas is cleared to command stack (044c1ea)
- [x] use dirty flag to update when snapshot needs to be taken (is this necessary?) (22908ae)