### PR TITLE
Support canvas background

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -14,6 +14,7 @@ declare global {
 			 * Current image src.
 			 */
 			src: string;
+			background: string;
 			undoStack: Command[];
 			redoStack: Command[];
 		}

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -21,7 +21,6 @@ declare global {
 
 			/**
 			 * The background color of the frame
-			 * TODO: improve this!
 			 */
 			background: string;
 			undoStack: Command[];

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -25,11 +25,6 @@ declare global {
 			commands: { (...args: any[]): void }[];
 			execute: (commands: { (...args: any[]): void }[], ...args: any[]) => void;
 		}
-
-		type FrameOptions = Writable<{
-			bg: string;
-			size: [number, number];
-		}>;
 	}
 }
 

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -11,9 +11,18 @@ declare global {
 			 */
 			dirty: boolean;
 			/**
-			 * Current image src.
+			 * The source of the image to render as an overlay (i.e. source minus bg)
 			 */
-			src: string;
+			overlaySrc: string;
+			/**
+			 * The final rendered image
+			 */
+			renderSrc: string;
+
+			/**
+			 * The background color of the frame
+			 * TODO: improve this!
+			 */
 			background: string;
 			undoStack: Command[];
 			redoStack: Command[];
@@ -22,10 +31,13 @@ declare global {
 		// Holds a function to execute a series of commands, and a series of
 		// commands to execute
 		type Command = {
+			type: App.CommandType;
 			// A list of commands that can be executed. Each command is a function.
 			commands: { (...args: any[]): void }[];
 			execute: (commands: { (...args: any[]): void }[], ...args: any[]) => void;
 		}
+
+		type CommandType = "draw" | "clear" ;
 	}
 }
 

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,12 +1,10 @@
 // See https://kit.svelte.dev/docs/types#app
+
+import type { Writable } from "svelte/store";
+
 // for information about these interfaces
 declare global {
 	namespace App {
-		// interface Error {}
-		// interface Locals {}
-		// interface PageData {}
-		// interface PageState {}
-		// interface Platform {}
 		type Frame = {
 			/**
 			 * Whether or not the command stack has been modified since the last image save.
@@ -27,9 +25,12 @@ declare global {
 			commands: { (...args: any[]): void }[];
 			execute: (commands: { (...args: any[]): void }[], ...args: any[]) => void;
 		}
+
+		type FrameOptions = Writable<{
+			bg: string;
+			size: [number, number];
+		}>;
 	}
 }
-
-export interface CropTarget {}
 
 export {};

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { size, matrix, frames } from "$lib/stores";
+  import { size, bg, matrix, frames } from "$lib/stores";
   import { onMount } from "svelte";
 
   export let playing: boolean = false;
@@ -202,6 +202,9 @@
 />
 
 <canvas
+  style="--bg: {$bg === 'transparent'
+    ? 'repeating-conic-gradient(#ddd 0% 25%, white 0% 50%) 50% / 10px 10px'
+    : $bg};"
   bind:this={canvas}
   on:mousedown={(e) => {
     if (playing) return;
@@ -212,8 +215,7 @@
 <style>
   canvas {
     position: absolute;
-    background: repeating-conic-gradient(#ddd 0% 25%, transparent 0% 50%) 50% /
-      10px 10px;
-    border: 1px solid rgba(0 0 0 / 25%) inset;
+    background: var(--bg);
+    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.15);
   }
 </style>

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -45,7 +45,7 @@
 
   let lastPos: [number, number] = [0, 0];
   const handleDraw = (e: MouseEvent) => {
-    if (!ctx || panEnabled) return;
+    if (panEnabled) return;
 
     const [x, y] = [
       (e.clientX - canvas.getBoundingClientRect().left) / $matrix[0],
@@ -99,7 +99,7 @@
       // TODO: is shallow copy necessary?
       commands: [...actionCommands],
       // @ts-ignore (sveltekit try to type inlined JS challenge (impossible))
-      execute: (commands, ctx) => {
+      execute: (commands, ctx: CanvasRenderingContext2D) => {
         for (const command of commands) command(ctx);
       },
     };
@@ -145,7 +145,6 @@
   };
 
   const replicateFrameState = () => {
-    if (!ctx) throw new Error("no context");
     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
     // fill with background
@@ -166,7 +165,6 @@
    * while maintaining undo/redo functionality.
    */
   export const clearFrame = () => {
-    if (!ctx) throw new Error("no context");
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.fillStyle = frame.background;
     ctx.fillRect(0, 0, canvas.width, canvas.height);
@@ -198,9 +196,9 @@
     frame.renderSrc = src;
 
     // clear canvas, then draw overlay source (transparent background + commands)
-    ctx?.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
     for (const { type, commands, execute } of frame.undoStack) {
-      if (type === "clear") ctx?.clearRect(0, 0, canvas.width, canvas.height);
+      if (type === "clear") ctx.clearRect(0, 0, canvas.width, canvas.height);
       else execute(commands, ctx);
     }
 

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { size, bg, matrix, frames } from "$lib/stores";
+  import { size, matrix, frames } from "$lib/stores";
   import { onMount } from "svelte";
 
   export let playing: boolean = false;
@@ -14,6 +14,7 @@
 
   // FIXME: this is shaky; assert frame is never null/undefined
   $: frame = $frames[frameIdx];
+  $: frameBackground = frame?.background ?? "#ffffff";
 
   /**
    * when the frame changes, we need to replicate the frame state.
@@ -135,7 +136,6 @@
   };
 
   const replicateFrameState = () => {
-    console.log(frame);
     if (!ctx) throw new Error("no context");
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     for (const { commands, execute } of frame.undoStack) {
@@ -202,9 +202,9 @@
 />
 
 <canvas
-  style="--bg: {$bg === 'transparent'
+  style="--bg: {frameBackground === 'transparent'
     ? 'repeating-conic-gradient(#ddd 0% 25%, white 0% 50%) 50% / 10px 10px'
-    : $bg};"
+    : frameBackground};"
   bind:this={canvas}
   on:mousedown={(e) => {
     if (playing) return;

--- a/src/lib/frames.ts
+++ b/src/lib/frames.ts
@@ -6,6 +6,7 @@
  */
 export const createEmptyFrame = (canvas: HTMLCanvasElement): App.Frame => ({
   dirty: false,
+  background: "#ffffff", // TODO: Use bg store
   src: canvas.toDataURL(),
   redoStack: [],
   undoStack: [],

--- a/src/lib/frames.ts
+++ b/src/lib/frames.ts
@@ -5,10 +5,11 @@
  * @returns {App.Frame} Empty frame object
  */
 export const createEmptyFrame = (canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D, fill: string): App.Frame => {
+  // capture overlay source as transparent image
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   const overlaySrc = canvas.toDataURL();
 
-  // reset canvas
+  // capture initial render source as filled image
   ctx.fillStyle = fill;
   ctx.fillRect(0, 0, canvas.width, canvas.height);
 

--- a/src/lib/frames.ts
+++ b/src/lib/frames.ts
@@ -4,12 +4,22 @@
  * @param canvas Canvas element to generate empty frame image from
  * @returns {App.Frame} Empty frame object
  */
-export const createEmptyFrame = (canvas: HTMLCanvasElement): App.Frame => ({
-  dirty: false,
-  background: "#ffffff", // TODO: Use bg store
-  src: canvas.toDataURL(),
-  redoStack: [],
-  undoStack: [],
-});
+export const createEmptyFrame = (canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D, fill: string): App.Frame => {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const overlaySrc = canvas.toDataURL();
+
+  // reset canvas
+  ctx.fillStyle = fill;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  return {
+    dirty: false,
+    background: fill,
+    renderSrc: canvas.toDataURL(),
+    overlaySrc,
+    redoStack: [],
+    undoStack: [],
+  };
+};
 
 

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,12 +1,6 @@
 import {writable, type Writable} from 'svelte/store';
 
+export const size = writable([0, 0]);
+export const bg = writable(`#ffffff`);
 export const matrix = writable([1, 0, 0, 1, 0, 0]);
 export const frames: Writable<App.Frame[]> = writable([]);
-
-/**
- * Reactive object for frame render options
- */
-export const opts: App.FrameOptions = writable({
-  bg: `#ffffff`,
-  size: [0, 0],
-});

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,5 +1,12 @@
 import {writable, type Writable} from 'svelte/store';
 
-export const size = writable([0, 0]);
 export const matrix = writable([1, 0, 0, 1, 0, 0]);
 export const frames: Writable<App.Frame[]> = writable([]);
+
+/**
+ * Reactive object for frame render options
+ */
+export const opts: App.FrameOptions = writable({
+  bg: `#ffffff`,
+  size: [0, 0],
+});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Canvas from "$lib/components/Canvas.svelte";
-  import { size, matrix, frames } from "$lib/stores";
+  import { size, bg, matrix, frames } from "$lib/stores";
   import { createEmptyFrame } from "$lib/frames";
   import transforms from "$lib/transforms";
   import { onMount } from "svelte";
@@ -60,8 +60,7 @@
     }
   };
 
-  onMount(async () => {
-    // capture first frame on mount
+  onMount(() => {
     $frames = [createEmptyFrame(canvas)];
 
     requestAnimationFrame(update);
@@ -226,6 +225,11 @@
       y
       <input type="number" bind:value={$size[1]} min="1" />
     </label>
+    <label class="lbl-horz">
+      bg
+      <!-- // initial white -->
+      <input type="color" bind:value={$bg} />
+    </label>
   </fieldset>
 </section>
 
@@ -238,6 +242,9 @@
     {@const src = frame.src}
     <div
       class="capture"
+      style="--bg: {$bg === 'transparent'
+        ? 'repeating-conic-gradient(#ddd 0% 25%, white 0% 50%) 50% / 10px 10px'
+        : $bg};"
       style:border-color={frameIdx === i ? "red" : "black"}
       bind:clientHeight={frameContainerHeight}
       style:width="{width}px"
@@ -282,6 +289,7 @@
   }
 
   #viewer-container {
+    background-color: rgb(240, 240, 240);
     position: relative;
     overflow: hidden;
     gap: 1rem;
@@ -313,6 +321,8 @@
     height: 100%;
     border-style: solid;
     align-self: flex-start;
+    padding: 2px;
+    background-color: var(--bg);
   }
 
   .capture > img {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -225,11 +225,6 @@
       y
       <input type="number" bind:value={$size[1]} min="1" />
     </label>
-    <label class="lbl-horz">
-      bg
-      <!-- // initial white -->
-      <input type="color" bind:value={$bg} />
-    </label>
   </fieldset>
 </section>
 
@@ -242,9 +237,9 @@
     {@const src = frame.src}
     <div
       class="capture"
-      style="--bg: {$bg === 'transparent'
+      style="--bg: {frame.background === 'transparent'
         ? 'repeating-conic-gradient(#ddd 0% 25%, white 0% 50%) 50% / 10px 10px'
-        : $bg};"
+        : frame.background};"
       style:border-color={frameIdx === i ? "red" : "black"}
       bind:clientHeight={frameContainerHeight}
       style:width="{width}px"
@@ -255,15 +250,10 @@
       <button
         class="delete"
         on:click={() => {
+          if (!ctx) throw new Error("Error clearing canvas: Context is null.");
           if ($frames.length === 1) {
-            frames.update((f) => [
-              {
-                src: "",
-                dirty: false,
-                undoStack: [],
-                redoStack: [],
-              },
-            ]);
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            $frames = [createEmptyFrame(canvas)];
             frameIdx = 0;
             return;
           }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -67,8 +67,6 @@
 
     ctx = context;
 
-    $frames = [createEmptyFrame(canvas, ctx, $bg)];
-
     requestAnimationFrame(update);
   });
 
@@ -231,6 +229,14 @@
       y
       <input type="number" bind:value={$size[1]} min="1" />
     </label>
+    <label class="lbl-horz">
+      bg
+      <input
+        type="color"
+        bind:value={$bg}
+        on:change={() => console.log("updated")}
+      />
+    </label>
   </fieldset>
 </section>
 
@@ -243,9 +249,6 @@
     {@const src = frame.renderSrc}
     <div
       class="capture"
-      style="--bg: {frame.background === 'transparent'
-        ? 'repeating-conic-gradient(#ddd 0% 25%, white 0% 50%) 50% / 10px 10px'
-        : frame.background};"
       style:border-color={frameIdx === i ? "red" : "black"}
       bind:clientHeight={frameContainerHeight}
       style:width="{width}px"
@@ -318,7 +321,6 @@
     border-style: solid;
     align-self: flex-start;
     padding: 2px;
-    background-color: var(--bg);
   }
 
   .capture > img {


### PR DESCRIPTION
Dirty implementation. Current uses CSS background.

Initially did this as overlay would render background over lines.

Proper support requires layers.

- [x] Use separate preview and overlay src (with/without background rendered, respectively) (66ef809)