### PR TITLE
append existing line command to frame when `captureFrame()` called before `mouseup` event

### DIFF
--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -172,6 +172,7 @@
    * presses the "capture" button in the toolbar.
    */
   export const captureFrame = () => {
+    if (actionCommands.length > 0) pushCommandToStack();
     if (!frame.dirty) return;
 
     let src = canvas.toDataURL();


### PR DESCRIPTION
Closes #21 