### PR TITLE
f/16 reset canvas view

### DIFF
--- a/src/lib/transforms.ts
+++ b/src/lib/transforms.ts
@@ -8,6 +8,14 @@ const transforms = () => {
   let scale = 1;
   let dirty = false;
 
+  const reset = () => {
+    matrix.set([0.9, 0, 0, 0.9, 0, 0]);
+    mat = [1, 0, 0, 1, 0, 0];
+    pos = [0, 0];
+    scale = 1;
+    dirty = false;
+  }
+
   const apply = () => {
     if (dirty) updateMatrix();
     matrix.set(mat);
@@ -38,8 +46,16 @@ const transforms = () => {
   return {
     pan,
     zoom,
-    apply
+    apply,
+    reset
   };
 };
 
-export default transforms;
+let transformsInstance: ReturnType<typeof transforms>;
+
+const getTransforms = () => {
+  if (!transformsInstance) transformsInstance = transforms();
+  return transformsInstance;
+};
+
+export default getTransforms;

--- a/src/lib/transforms.ts
+++ b/src/lib/transforms.ts
@@ -5,14 +5,14 @@ import { matrix } from "$lib/stores";
 const transforms = () => {
   let mat = [1, 0, 0, 1, 0, 0];
   let pos = [0, 0];
-  let scale = 1;
+  let scale = 0.9;
   let dirty = false;
 
   const reset = () => {
     matrix.set([0.9, 0, 0, 0.9, 0, 0]);
     mat = [1, 0, 0, 1, 0, 0];
     pos = [0, 0];
-    scale = 1;
+    scale = 0.9;
     dirty = false;
   }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -226,6 +226,9 @@
   <fieldset>
     <legend>canvas controls</legend>
     <button on:click={clearFrame}>Clear</button>
+    <button on:click={() => ($matrix = [0.9, 0, 0, 0.9, 0, 0])}>
+      reset view
+    </button>
     <label class="lbl-horz">
       x
       <input type="number" bind:value={$size[0]} min="1" />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,11 +2,9 @@
   import Canvas from "$lib/components/Canvas.svelte";
   import { frameIdx, size, bg, matrix, frames } from "$lib/stores";
   import { createEmptyFrame } from "$lib/frames";
-  import transforms from "$lib/transforms";
+  import getTransforms from "$lib/transforms";
   import { onMount } from "svelte";
   import Capture from "$lib/components/Capture.svelte";
-
-  let viewTransforms = transforms();
 
   /**
    * Binding for current frame that clears canvas and updates frame command
@@ -79,8 +77,8 @@
 
     if (!panEnabled) return;
 
-    viewTransforms.pan([mousePos[0] - lastPos[0], mousePos[1] - lastPos[1]]);
-    viewTransforms.apply();
+    getTransforms().pan([mousePos[0] - lastPos[0], mousePos[1] - lastPos[1]]);
+    getTransforms().apply();
     e.preventDefault();
   };
 
@@ -90,8 +88,8 @@
 
     const factor = e.deltaY > 0 ? 0.9 : 1.1;
 
-    viewTransforms.zoom([x, y], factor);
-    viewTransforms.apply();
+    getTransforms().zoom([x, y], factor);
+    getTransforms().apply();
     e.preventDefault();
   };
 
@@ -101,8 +99,8 @@
 
     if (e.shiftKey) [x, y] = [y, x];
 
-    viewTransforms.pan([-x, -y]);
-    viewTransforms.apply();
+    getTransforms().pan([-x, -y]);
+    getTransforms().apply();
     e.preventDefault();
   };
 
@@ -226,9 +224,7 @@
   <fieldset>
     <legend>canvas controls</legend>
     <button on:click={clearFrame}>Clear</button>
-    <button on:click={() => ($matrix = [0.9, 0, 0, 0.9, 0, 0])}>
-      reset view
-    </button>
+    <button on:click={() => getTransforms().reset()}> reset view </button>
     <label class="lbl-horz">
       x
       <input type="number" bind:value={$size[0]} min="1" />


### PR DESCRIPTION
Closes #16

Switches default `transform.ts` export to singleton; adds `reset()` function to default matrix to 0.9 zoom.