### PR TITLE
Implement FFmpeg export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,10 @@
 		"": {
 			"name": "animapper",
 			"version": "0.0.1",
+			"dependencies": {
+				"@ffmpeg/core": "^0.11.0",
+				"@ffmpeg/ffmpeg": "^0.11.6"
+			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^3.0.0",
 				"@sveltejs/kit": "^2.0.0",
@@ -381,6 +385,25 @@
 			],
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/@ffmpeg/core": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@ffmpeg/core/-/core-0.11.0.tgz",
+			"integrity": "sha512-9Tt/+2PMpkGPXUK8n6He9G8Y+qR6qmCPSCw9iEKZxHHOvJ9BE/r0Fccj+YgDZTlyu6rXxc9x6EqCaFBIt7qzjA=="
+		},
+		"node_modules/@ffmpeg/ffmpeg": {
+			"version": "0.11.6",
+			"resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.11.6.tgz",
+			"integrity": "sha512-uN8J8KDjADEavPhNva6tYO9Fj0lWs9z82swF3YXnTxWMBoFLGq3LZ6FLlIldRKEzhOBKnkVfA8UnFJuvGvNxcA==",
+			"dependencies": {
+				"is-url": "^1.2.4",
+				"node-fetch": "^2.6.1",
+				"regenerator-runtime": "^0.13.7",
+				"resolve-url": "^0.2.1"
+			},
+			"engines": {
+				"node": ">=12.16.1"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
@@ -1226,6 +1249,11 @@
 				"@types/estree": "*"
 			}
 		},
+		"node_modules/is-url": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+			"integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+		},
 		"node_modules/kleur": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -1365,6 +1393,25 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1493,6 +1540,11 @@
 				"node": ">=8.10.0"
 			}
 		},
+		"node_modules/regenerator-runtime": {
+			"version": "0.13.11",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -1501,6 +1553,12 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
+			"deprecated": "https://github.com/lydell/resolve-url#deprecated"
 		},
 		"node_modules/reusify": {
 			"version": "1.0.4",
@@ -1819,6 +1877,11 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+		},
 		"node_modules/tslib": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -1913,6 +1976,20 @@
 				"vite": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+		},
+		"node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -19,5 +19,9 @@
 		"typescript": "^5.0.0",
 		"vite": "^5.0.3"
 	},
-	"type": "module"
+	"type": "module",
+	"dependencies": {
+		"@ffmpeg/core": "^0.11.0",
+		"@ffmpeg/ffmpeg": "^0.11.6"
+	}
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -37,6 +37,10 @@ declare global {
 		}
 
 		type CommandType = "draw" | "clear" ;
+
+		type ExportOptions = {
+			framerate: number;
+		}
 	}
 }
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,33 @@
+import type { Handle } from "@sveltejs/kit";
+
+export const handle: Handle = async ({ resolve, event }) => {
+  const response = await resolve(event);
+
+  /**
+   * We return our response as usual, but we append two headers:
+   * - Cross-Origin-Embedder-Policy: require-corp
+   * - Cross-Origin-Opener-Policy: same-origin
+   *
+   * These headers make out document cross-origin-isolated, which means the
+   * following restrictions are applied:
+   * - window-level: ensures document cannot share a browsing context group with
+   * documents outside of its own origin.
+   * - resource-loading: prevents document from making cross-origin requests
+   * arbitrarily.
+   *
+   * The document must be cross-origin-isolated in order to use
+   * SharedArrayBuffer
+   *
+   * Dumping some reading here for future reference because I know i'll forget
+   * about Spectre:
+   * https://docs.google.com/document/d/1zDlfvfTJ_9e8Jdc8ehuV4zMEu9ySMCiTGMS9y0GU92k/
+   * https://docs.google.com/presentation/d/1sadl7jTrBIECCanuqSrNndnDr82NGW1yyuXFT1Dc7SQ/
+   */
+  return new Response(response.body, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Headers": "*",
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
+  }});
+};

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -1,0 +1,34 @@
+
+import { frames, ffmpeg } from "$lib/stores"
+import { get } from "svelte/store";
+import { fetchFile } from "@ffmpeg/ffmpeg";
+
+export const exportRender = async (options: App.ExportOptions): Promise<boolean> => {
+  // get all render sources from frame store
+  const renders: string[] = get(frames).map((frame => frame.renderSrc));
+  const ffmpegInstance = get(ffmpeg);
+
+  if(!ffmpegInstance.isLoaded) {
+    throw new Error("Error exporting: ffmpeg is not loaded");
+  }
+
+  for (const render of renders) {
+    ffmpegInstance.FS("writeFile", `render-${renders.indexOf(render)}.png`, await fetchFile(render));
+  }
+
+  // run ffmpeg command to concat all renders with name `render-<index>.png` into a video with specified framerate.
+  await ffmpegInstance.run("-framerate", `${options.framerate}`, "-i", "render-%d.png", "-pix_fmt", "yuv420p", "out.mp4");
+  const data = ffmpegInstance.FS("readFile", "out.mp4");
+
+  // Download the file by creating a new link, and dispatching a click event
+  const link = document.createElement("a");
+  link.download = `out.mp4`;
+  link.href = URL.createObjectURL(new Blob([data.buffer], { type: "video/mp4" }));
+  document.body.appendChild(link);
+  link.dispatchEvent(new MouseEvent("click"));
+
+  // Clean up
+  document.body.removeChild(link);
+  setTimeout(() => URL.revokeObjectURL(link.href), 7000);
+  return true;
+}

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,3 +1,4 @@
+import { createFFmpeg, type FFmpeg } from '@ffmpeg/ffmpeg';
 import {writable, type Writable} from 'svelte/store';
 
 export const frameIdx = writable(0);
@@ -5,3 +6,6 @@ export const size = writable([0, 0]);
 export const bg = writable(`#ffffff`);
 export const matrix = writable([0.9, 0, 0, 0.9, 0, 0]);
 export const frames: Writable<App.Frame[]> = writable([]);
+export const ffmpeg: Writable<FFmpeg> = writable(createFFmpeg({
+  log: true,
+}));

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,9 +1,22 @@
-<script>
+<script lang="ts">
+  import { createFFmpeg } from "@ffmpeg/ffmpeg";
+  import { onMount } from "svelte";
+
+  let ffmpeg = createFFmpeg({ log: true });
+  let ffmpegLoaded = false;
+
+  onMount(async () => {
+    await ffmpeg.load();
+    ffmpegLoaded = true;
+  });
+
   import "./app.css";
 </script>
 
 <main>
-  <slot />
+  {#if ffmpegLoaded}
+    <slot />
+  {/if}
 </main>
 
 <style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-  import { createFFmpeg } from "@ffmpeg/ffmpeg";
+  import { ffmpeg } from "$lib/stores";
   import { onMount } from "svelte";
 
-  let ffmpeg = createFFmpeg({ log: true });
   let ffmpegLoaded = false;
 
   onMount(async () => {
-    await ffmpeg.load();
+    await $ffmpeg.load();
     ffmpegLoaded = true;
   });
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,6 +5,7 @@
   import getTransforms from "$lib/transforms";
   import { onMount } from "svelte";
   import Capture from "$lib/components/Capture.svelte";
+  import { exportRender } from "$lib/export";
 
   /**
    * Binding for current frame that clears canvas and updates frame command
@@ -237,6 +238,11 @@
       bg
       <input type="color" bind:value={$bg} />
     </label>
+  </fieldset>
+
+  <fieldset>
+    <legend>render</legend>
+    <button on:click={() => exportRender({ framerate })}>export</button>
   </fieldset>
 </section>
 


### PR DESCRIPTION
Closes #7; closes #35

Adds export option via [ffmpeg.wasm](https://ffmpegwasm-0-11-x.netlify.app/) (0.11.x branch since 0.12 branch doesn't seem to work on [SvelteKit](https://github.com/ffmpegwasm/ffmpeg.wasm/issues/603))