### PR TITLE
Force even dimensions on canvas

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -95,6 +95,7 @@ declare global {
 		 */
 		type ExportOptions = {
 			framerate: number;
+			size: [number, number];
 		}
 	}
 }

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { bg, size, matrix, frames, frameIdx } from "$lib/stores";
+  import { bg, exportSafeSize, matrix, frames, frameIdx } from "$lib/stores";
   import { retrieveStoredFrames, saveFramesToStorage } from "$lib/frames";
   import { onMount } from "svelte";
 
@@ -49,7 +49,7 @@
      * a valid frame/canvas context.
      */
 
-    size.subscribe((size) => {
+    exportSafeSize.subscribe((size) => {
       canvas.width = size[0];
       canvas.height = size[1];
 

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -22,7 +22,10 @@ export const exportRender = async (options: App.ExportOptions): Promise<boolean>
   }
 
   // run ffmpeg command to concat all renders with name `render-<index>.png` into a video with specified framerate.
-  await ffmpegInstance.run("-framerate", `${options.framerate}`, "-i", "render-%d.png", "-pix_fmt", "yuv420p", "out.mp4");
+  await ffmpegInstance.run("-framerate", `${options.framerate}`, "-s",
+    options.size.join("x"), "-i", "render-%d.png", "-pix_fmt", "yuv420p",
+    "out.mp4");
+
   const data = ffmpegInstance.FS("readFile", "out.mp4");
 
   // Download the file by creating a new link, and dispatching a click event

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,5 +1,5 @@
 import { createFFmpeg, type FFmpeg } from '@ffmpeg/ffmpeg';
-import {derived, writable, type Writable} from 'svelte/store';
+import {derived, writable, type Readable, type Writable} from 'svelte/store';
 
 export const frameIdx = writable(0);
 export const size: Writable<[number,number]> = writable([0, 0]);
@@ -8,10 +8,10 @@ export const size: Writable<[number,number]> = writable([0, 0]);
  * A rounded size that is safe to send to ffmpeg for export (because ffmpeg
  * requires dimensions to be divisible by 2)
  */
-export const exportSafeSize = derived(size, ([width, height]) => {
+export const exportSafeSize: Readable<[number,number]> = derived(size, ([width, height]) => {
   // round to nearest multiple of 2
   // i.e. 3 -> 2, 4 -> 4, 5 -> 4, 6 -> 6, etc.
-  return [Math.floor((width) / 2) * 2, Math.floor((height) / 2) * 2];
+  return [Math.floor((width) / 2) * 2, Math.floor((height) / 2) * 2] as [number, number];
 });
 
 export const bg = writable(`#ffffff`);

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,8 +1,19 @@
 import { createFFmpeg, type FFmpeg } from '@ffmpeg/ffmpeg';
-import {writable, type Writable} from 'svelte/store';
+import {derived, writable, type Writable} from 'svelte/store';
 
 export const frameIdx = writable(0);
 export const size: Writable<[number,number]> = writable([0, 0]);
+
+/**
+ * A rounded size that is safe to send to ffmpeg for export (because ffmpeg
+ * requires dimensions to be divisible by 2)
+ */
+export const exportSafeSize = derived(size, ([width, height]) => {
+  // round to nearest multiple of 2
+  // i.e. 3 -> 2, 4 -> 4, 5 -> 4, 6 -> 6, etc.
+  return [Math.floor((width) / 2) * 2, Math.floor((height) / 2) * 2];
+});
+
 export const bg = writable(`#ffffff`);
 export const matrix = writable([0.9, 0, 0, 0.9, 0, 0]);
 export const frames: Writable<App.Frame[]> = writable([]);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
   import Canvas from "$lib/components/Canvas.svelte";
-  import { frameIdx, size, bg, matrix, frames } from "$lib/stores";
+  import {
+    frameIdx,
+    size,
+    bg,
+    matrix,
+    frames,
+    exportSafeSize,
+  } from "$lib/stores";
   import { createEmptyFrame } from "$lib/frames";
   import getTransforms from "$lib/transforms";
   import { onMount } from "svelte";
@@ -155,6 +162,15 @@
 
     $frameIdx++;
   };
+
+  /**
+   * Rounds the size input to the nearest multiple of 2, if it mismatches the
+   * safely-exportable size store
+   */
+  const roundSizeInput = () => {
+    if ($size[0] % 2 !== 0) $size[0] = Math.ceil($size[0] / 2) * 2;
+    if ($size[1] % 2 !== 0) $size[1] = Math.ceil($size[1] / 2) * 2;
+  };
 </script>
 
 <svelte:window
@@ -266,7 +282,9 @@
       <input
         type="number"
         bind:value={$size[0]}
-        min="1"
+        on:change={roundSizeInput}
+        step="2"
+        min="16"
         disabled={!isProjectEmpty}
       />
     </label>
@@ -275,7 +293,9 @@
       <input
         type="number"
         bind:value={$size[1]}
-        min="1"
+        on:change={roundSizeInput}
+        step="2"
+        min="16"
         disabled={!isProjectEmpty}
       />
     </label>
@@ -287,7 +307,9 @@
 
   <fieldset>
     <legend>render</legend>
-    <button on:click={() => exportRender({ framerate })}>export</button>
+    <button on:click={() => exportRender({ framerate, size: $exportSafeSize })}
+      >export</button
+    >
   </fieldset>
 </section>
 


### PR DESCRIPTION
Closes #45 

ffmpeg requires even dimensions for export; this PR adds a derived store to ensure the canvas and ffmpeg are always provided with even export dimensions